### PR TITLE
Add asset caching and fix frontend build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ frontend/build/
 *.swp
 *.swo
 .DS_Store
+frontend/.svelte-kit/

--- a/README.md
+++ b/README.md
@@ -22,13 +22,21 @@ A standalone Rust application that renders Mermaid diagrams to PNG files without
    cd mermaid_render
    ```
 
-2. Run the setup script to download and prepare the required assets:
+2. Run the setup script to download and prepare the required assets. The script
+   uses a cache so assets are only downloaded the first time:
    ```bash
    chmod +x setup_assets.sh
    ./setup_assets.sh
    ```
 
-3. Build the release binary:
+3. Install the frontend dependencies and build the UI:
+   ```bash
+   cd frontend
+   npm install
+   npm run build
+   cd ..
+   ```
+4. Build the release binary:
    ```bash
    cargo build --release
    ```

--- a/frontend/src/app.html
+++ b/frontend/src/app.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    %sveltekit.head%
+  </head>
+  <body data-sveltekit-preload-data="hover">
+    <div style="display: contents">%sveltekit.body%</div>
+  </body>
+</html>

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,6 @@
+import { sveltekit } from '@sveltejs/kit/vite';
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  plugins: [sveltekit()]
+});

--- a/prepare_assets.sh
+++ b/prepare_assets.sh
@@ -15,6 +15,10 @@ echo "--- Preparing assets for mermaid_render ---"
 
 # 1. Create the resources directory
 echo "1. Creating './${RESOURCES_DIR}' directory..."
+if [ -f "${RESOURCES_DIR}/node" ] && [ -f "${RESOURCES_DIR}/@mermaid-js/mermaid-cli/dist/cli.js" ]; then
+    echo "Resources already present. Skipping download."
+    exit 0
+fi
 rm -rf "${RESOURCES_DIR}"  # Clean up any existing resources
 mkdir -p "${RESOURCES_DIR}"
 

--- a/setup_assets.sh
+++ b/setup_assets.sh
@@ -10,6 +10,10 @@ NODE_URL="https://nodejs.org/dist/v${NODE_VERSION}/${NODE_FILENAME}.tar.gz"
 
 # Clean up and create directories
 echo "1. Setting up directories..."
+if [ -f "${RESOURCES_DIR}/node" ] && [ -f "${RESOURCES_DIR}/node_modules/.bin/mmdc" ]; then
+    echo "Resources already present. Skipping download."
+    exit 0
+fi
 rm -rf "${RESOURCES_DIR}"
 mkdir -p "${RESOURCES_DIR}/nodejs"
 

--- a/tauri.conf.json
+++ b/tauri.conf.json
@@ -3,7 +3,7 @@
     "beforeDevCommand": "npm run dev --prefix frontend",
     "beforeBuildCommand": "npm run build --prefix frontend",
     "devPath": "http://localhost:5173",
-    "distDir": "../frontend/build",
+    "distDir": "frontend/build",
     "withGlobalTauri": true
   },
   "package": {


### PR DESCRIPTION
## Summary
- only download Node and Mermaid assets when missing
- document building the frontend and note caching
- ensure Tauri uses the correct `distDir`
- add missing SvelteKit build files

## Testing
- `npm run build` within `frontend`
- `cargo check` *(fails: gdk-3.0 missing)*

------
https://chatgpt.com/codex/tasks/task_b_6873d827d2008330b69aec00bb56b4e2